### PR TITLE
fix: update release-please configuration to include component in tag

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,6 +5,7 @@
   "packages": {
     ".": {
       "package-name": "z_image_editor",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
This pull request makes a configuration adjustment to the `.release-please-config.json` file for the `z_image_editor` package. The change disables the inclusion of the component name in generated release tags.

- Release configuration:
  * Set `"include-component-in-tag"` to `false` for the `z_image_editor` package in `.release-please-config.json`, so release tags will not include the component name.