### PR TITLE
fix: add platform_types.dart to resolve dart:io File type conflict on web

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,64 @@ For a complete integration example covering all platforms, see [`example/lib/mai
 
 Passing the wrong combination throws an `ArgumentError` at startup with a clear message.
 
+### Cross-platform builds — avoiding `dart:io File` compile errors
+
+If your app compiles for **both mobile and web**, passing a `dart:io File` to
+`imageFiles` will produce a compile error on web:
+
+```
+Error: The argument type 'File/*1*/' can't be assigned to the parameter type 'File/*2*/'.
+ - 'File/*1*/' is from 'dart:io'.
+ - 'File/*2*/' is from 'package:z_image_editor/src/utils/platform_io_web.dart'.
+```
+
+This happens because the package uses a conditional import for `File` internally
+(`dart:io` on mobile, a lightweight stub on web), so the two `File` types are
+distinct at compile time.
+
+**Option 1 — use `imageBytesList` (recommended for cross-platform code)**
+
+Read the file bytes yourself and pass them as `imageBytesList`. This API works
+on both mobile and web with no type conflict:
+
+```dart
+Future<File> _openEditor(BuildContext context, File imageFile) async {
+  final bytes = await imageFile.readAsBytes();
+  if (!context.mounted) return imageFile;
+
+  final editedFiles = await Navigator.of(context).push<List<File>>(
+    MaterialPageRoute(
+      builder: (ctx) => ZImageEditor(
+        imageBytesList: [bytes],           // ✅ no File type involved
+        onSaveAll: (f) => Navigator.of(ctx).pop(f),
+        onCancel: () => Navigator.of(ctx).pop(),
+      ),
+    ),
+  );
+  return editedFiles?.first ?? imageFile;
+}
+```
+
+**Option 2 — import `File` from the package instead of `dart:io`**
+
+The package ships `lib/platform_types.dart`, a public conditional export that
+resolves to `dart:io File` on mobile and the web stub on web. Importing it
+makes the types match on every platform:
+
+```dart
+import 'package:z_image_editor/platform_types.dart'; // ← instead of 'dart:io'
+```
+
+Everything else stays the same — `imageFiles`, `onSaveAll`, etc. still work as
+documented. Just remember that `imageFiles` must still be guarded so it is not
+*used* at runtime on web:
+
+```dart
+if (!kIsWeb) {
+  // safe to pass imageFiles here
+}
+```
+
 ## Configuration
 
 All parameters are optional beyond the platform-appropriate image input and save callback.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,11 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:z_image_editor/image_editor.dart';
 
-// Use the same conditional File as the package so types are compatible.
-// On native this resolves to dart:io; on web to the package's File stub.
-// ignore: uri_does_not_exist
-import 'dart:io'
-    if (dart.library.html) 'package:z_image_editor/src/utils/platform_io_web.dart';
+// Use the package's public conditional export so File types are compatible on
+// both mobile (dart:io) and web (package stub). See platform_types.dart.
+import 'package:z_image_editor/platform_types.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/platform_types.dart
+++ b/lib/platform_types.dart
@@ -1,0 +1,17 @@
+/// Cross-platform [File] and [Directory] types for use with [ZImageEditor].
+///
+/// Import this file instead of `dart:io` when you pass [File] objects to
+/// [ZImageEditor.imageFiles] in a codebase that also compiles for web.
+///
+/// ```dart
+/// import 'package:z_image_editor/platform_types.dart';
+/// ```
+///
+/// On mobile this re-exports the real `dart:io` types, so behaviour is
+/// identical. On web it exports the package's lightweight stubs, which keeps
+/// the code compilable even though `imageFiles` must not be used at runtime on
+/// web (pass `imageBytesList` instead).
+library;
+
+export 'dart:io' if (dart.library.html) 'src/utils/platform_io_web.dart'
+    show File, Directory;


### PR DESCRIPTION
## Problem

When an app compiles for both mobile and web, passing a `dart:io File` to `imageFiles` causes a compile error:

```
Error: The argument type 'File/*1*/' can't be assigned to the parameter type 'File/*2*/'.
 - 'File/*1*/' is from 'dart:io'.
 - 'File/*2*/' is from 'package:z_image_editor/src/utils/platform_io_web.dart'.
```

This happens because the package uses a conditional import for `File` internally, making the types distinct at compile time on web.

## Solution

### 1. `lib/platform_types.dart` (new public export)

A conditional export that resolves to `dart:io File` on mobile and the package's web stub on web. Consumers can import this instead of `dart:io` to eliminate the type mismatch:

```dart
import 'package:z_image_editor/platform_types.dart'; // instead of 'dart:io'
```

### 2. README documentation

Added a new **Cross-platform builds** subsection under _Web API Contract_ explaining:
- What causes the error
- Option 1: use `imageBytesList` (recommended for cross-platform)
- Option 2: import `File` from `platform_types.dart`