### PR TITLE
perf: fix web save freeze — use native PNG encoder on web

### DIFF
--- a/lib/src/utils/image_processing.dart
+++ b/lib/src/utils/image_processing.dart
@@ -3,6 +3,7 @@ import 'dart:io'
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
 import 'package:z_image_editor/src/models/image_editor_state.dart';
@@ -175,11 +176,22 @@ class ImageProcessing {
     final picture = recorder.endRecording();
     final outputImage = await picture.toImage(outputW, outputH);
 
-    // Read raw RGBA pixels from the GPU texture instead of asking the driver
-    // to encode PNG directly. On iOS/Impeller the direct PNG readback can
-    // swap R and B channels (Metal is BGRA-native), producing scattered red/
-    // blue dots in the output. rawRgba gives us canonical RGBA bytes that we
-    // then encode to PNG entirely on the CPU via the `image` package.
+    // On web (CanvasKit / Skia-Wasm) the Flutter engine's built-in PNG writer
+    // is a highly-optimised C++ implementation that runs in microseconds.
+    // The iOS/Impeller R↔B channel-swap bug does not affect web, so we can
+    // use the fast path here and skip the slow pure-Dart img.encodePng route.
+    if (kIsWeb) {
+      final pngData =
+          await outputImage.toByteData(format: ui.ImageByteFormat.png);
+      outputImage.dispose();
+      if (pngData == null) throw Exception('Failed to encode image as PNG');
+      return pngData.buffer.asUint8List();
+    }
+
+    // On iOS/Impeller the direct PNG readback can swap R and B channels
+    // (Metal is BGRA-native), producing scattered red/blue dots in the output.
+    // Read raw RGBA pixels and encode via the pure-Dart `image` package to
+    // guarantee correct channel order on all native platforms.
     final rawData =
         await outputImage.toByteData(format: ui.ImageByteFormat.rawRgba);
     outputImage.dispose();


### PR DESCRIPTION
## Problem

When pressing **Save** in the image editor on desktop web, the UI freezes for 1–3 minutes before the edited image is returned to the app. This does not happen on mobile.

## Root Cause

In `_renderWysiwygToBytes` (image_processing.dart), after rendering the canvas frame:

```dart
// BEFORE — runs synchronously on the JS main thread
return Uint8List.fromList(img.encodePng(cpuImage));  // ← freeze here
```

`img.encodePng` from the `image` package is **pure Dart**. On mobile it runs in a native OS thread (fast). On web, Dart code runs on the JavaScript main thread — there are no real background threads for this workload. For a large image the LZ77 compressor inside `encodePng` can block the UI thread for minutes, preventing any repaints (including the saving spinner).

## Fix

On web, skip the pure-Dart encoder entirely and use `outputImage.toByteData(format: ui.ImageByteFormat.png)` instead:

```dart
// AFTER — on web, uses browser's native (Wasm/C++) PNG encoder
if (kIsWeb) {
  final pngData = await outputImage.toByteData(format: ui.ImageByteFormat.png);
  outputImage.dispose();
}
```

This is an `async` call that yields to the event loop, allowing Flutter to render the spinner before encoding begins, and completes in milliseconds using the browser's optimised native encoder.

The existing rawRgba + `img.encodePng` path is preserved for **all non-web platforms**, where it is still needed to work around the iOS/Impeller R↔B channel-swap bug (Metal is BGRA-native).