### PR TITLE
feat: skip re-encoding unmodified images and add output format control

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,6 +63,7 @@ class _HomePageState extends State<HomePage> {
             verticalMargin: 40, // px of space above & below the panel
             maxWidth: 900, // WebEditorShell takes 82% of this → ~900 px
             child: ZImageEditor(
+              outputFormat: ImageOutputFormat.auto,
               showAdjustTab: true,
               showCropTab: true,
               showCropToolbar: true,

--- a/lib/image_editor.dart
+++ b/lib/image_editor.dart
@@ -5,6 +5,7 @@ export 'src/z_image_editor_widget.dart' show ZImageEditor;
 
 // Models (for advanced usage)
 export 'src/models/image_editor_state.dart';
+export 'src/models/image_output_format.dart';
 export 'src/models/crop_toolbar_settings.dart';
 export 'src/models/crop_tab_settings.dart';
 export 'src/models/adjust_tab_settings.dart';

--- a/lib/src/models/image_output_format.dart
+++ b/lib/src/models/image_output_format.dart
@@ -1,0 +1,44 @@
+/// Controls how the editor encodes the output image when the user presses Done.
+///
+/// ## Adding new formats
+///
+/// To add a new format in the future (e.g. WebP):
+/// 1. Add a new value to this enum.
+/// 2. Add magic-byte detection in `ImageProcessing._detectInputFormat` so that
+///    [original] mode can detect the new format from input bytes.
+/// 3. Add an encode branch for the new format in
+///    `ImageProcessing._renderWysiwygToBytes`,
+///    `ImageProcessing._processImageFallbackToBytes`, and
+///    `ImageProcessing._processImageFallbackFromBytes`.
+enum ImageOutputFormat {
+  /// Return the original bytes/file unchanged when no edits have been applied.
+  /// Re-encode as PNG when edits are applied.
+  ///
+  /// This is the default and gives the best performance for unmodified images
+  /// while still producing a reliable PNG when the image has been changed.
+  auto,
+
+  /// Always re-encode the output as PNG, regardless of whether the image was
+  /// modified.
+  png,
+
+  /// Always re-encode the output as JPEG, regardless of whether the image was
+  /// modified.
+  jpeg,
+
+  /// Preserve the original image format where possible.
+  ///
+  /// Returns the original bytes/file unchanged when no edits have been applied.
+  ///
+  /// When edits are applied the original format is detected from the input
+  /// bytes' magic-byte signature:
+  /// - JPEG (`FF D8`) → re-encoded as JPEG
+  /// - Anything else (PNG, WebP, HEIC, etc.) → re-encoded as PNG
+  ///
+  /// **Note:** WebP and HEIC inputs that have been edited will be output as PNG
+  /// because the underlying `image` package does not currently support encoding
+  /// those formats. The original bytes are still returned unchanged when no
+  /// edits are applied. Support for more formats can be added in the future —
+  /// see the class-level doc comment above.
+  original,
+}

--- a/lib/src/utils/image_processing.dart
+++ b/lib/src/utils/image_processing.dart
@@ -7,7 +7,11 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
 import 'package:z_image_editor/src/models/image_editor_state.dart';
+import 'package:z_image_editor/src/models/image_output_format.dart';
 import 'package:z_image_editor/src/utils/transformation_service.dart';
+
+/// Detected format of an input image based on magic bytes.
+enum _InputFormat { jpeg, png }
 
 class ImageProcessing {
   /// Apply all edits to the image and return the processed image.
@@ -15,28 +19,54 @@ class ImageProcessing {
   /// Uses a WYSIWYG PictureRecorder approach when display size information is
   /// available, guaranteeing pixel-perfect accuracy between preview and output.
   /// Falls back to pixel-based processing otherwise.
+  ///
+  /// [outputFormat] controls the encoding of the output. Defaults to
+  /// [ImageOutputFormat.png]. When [ImageOutputFormat.original] is passed the
+  /// format is detected from the input file's magic bytes.
   static Future<File> processImage({
     required File originalFile,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
+    final bytes = await originalFile.readAsBytes();
+    final effectiveFormat = _resolveEffectiveFormat(outputFormat, bytes);
     if (state.displaySize != null) {
       return _processImageWysiwyg(
-        bytes: await originalFile.readAsBytes(),
+        bytes: bytes,
         state: state,
+        outputFormat: effectiveFormat,
       );
     }
-    return _processImageFallback(originalFile: originalFile, state: state);
+    return _processImageFallbackFromBytes(
+      bytes: bytes,
+      state: state,
+      outputFormat: effectiveFormat,
+    );
   }
 
   /// Process from raw bytes (for imageBytes: path).
+  ///
+  /// [outputFormat] controls the encoding of the output. Defaults to
+  /// [ImageOutputFormat.png]. When [ImageOutputFormat.original] is passed the
+  /// format is detected from the input bytes' magic bytes.
   static Future<File> processImageFromBytes({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
+    final effectiveFormat = _resolveEffectiveFormat(outputFormat, bytes);
     if (state.displaySize != null) {
-      return _processImageWysiwyg(bytes: bytes, state: state);
+      return _processImageWysiwyg(
+        bytes: bytes,
+        state: state,
+        outputFormat: effectiveFormat,
+      );
     }
-    return _processImageFallbackFromBytes(bytes: bytes, state: state);
+    return _processImageFallbackFromBytes(
+      bytes: bytes,
+      state: state,
+      outputFormat: effectiveFormat,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -54,16 +84,21 @@ class ImageProcessing {
   // where s = outputW / cropW  (output pixels per viewport pixel)
   // ---------------------------------------------------------------------------
   // WYSIWYG renderer — reproduces the exact pixel content visible in the crop
-  // window. The shared inner method [_renderWysiwygToBytes] returns raw PNG
-  // bytes. [_processImageWysiwyg] (mobile) writes them to a temp File.
-  // [processImageToBytes] (web) returns them directly.
+  // window. The shared inner method [_renderWysiwygToBytes] returns encoded
+  // bytes in the requested format. [_processImageWysiwyg] (mobile) writes them
+  // to a temp File. [processImageToBytes] (web) returns them directly.
   // ---------------------------------------------------------------------------
 
-  /// Returns PNG bytes for the WYSIWYG-rendered crop. Pure computation; no
+  /// Returns encoded bytes for the WYSIWYG-rendered crop. Pure computation; no
   /// filesystem access. Safe to call on web.
+  ///
+  /// [outputFormat] must be [ImageOutputFormat.png] or
+  /// [ImageOutputFormat.jpeg]; [auto] and [original] must be resolved before
+  /// calling this method.
   static Future<Uint8List> _renderWysiwygToBytes({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
     final codec = await ui.instantiateImageCodec(bytes);
     final frame = await codec.getNextFrame();
@@ -176,6 +211,24 @@ class ImageProcessing {
     final picture = recorder.endRecording();
     final outputImage = await picture.toImage(outputW, outputH);
 
+    if (outputFormat == ImageOutputFormat.jpeg) {
+      // JPEG: Flutter has no native JPEG encoder via toByteData, so read raw
+      // RGBA pixels and encode via the `image` package on all platforms.
+      final rawData =
+          await outputImage.toByteData(format: ui.ImageByteFormat.rawRgba);
+      outputImage.dispose();
+      if (rawData == null) throw Exception('Failed to read raw image pixels');
+      final cpuImage = img.Image.fromBytes(
+        width: outputW,
+        height: outputH,
+        bytes: rawData.buffer,
+        numChannels: 4,
+        order: img.ChannelOrder.rgba,
+      );
+      return Uint8List.fromList(img.encodeJpg(cpuImage, quality: 95));
+    }
+
+    // PNG path:
     // On web (CanvasKit / Skia-Wasm) the Flutter engine's built-in PNG writer
     // is a highly-optimised C++ implementation that runs in microseconds.
     // The iOS/Impeller R↔B channel-swap bug does not affect web, so we can
@@ -211,34 +264,52 @@ class ImageProcessing {
   static Future<File> _processImageWysiwyg({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
-    final pngBytes = await _renderWysiwygToBytes(bytes: bytes, state: state);
+    final encoded =
+        await _renderWysiwygToBytes(bytes: bytes, state: state, outputFormat: outputFormat);
     final tempDir = Directory.systemTemp;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final tempFile = File('${tempDir.path}/edited_$timestamp.png');
-    await tempFile.writeAsBytes(pngBytes);
+    final ext = outputFormat == ImageOutputFormat.jpeg ? 'jpg' : 'png';
+    final tempFile = File('${tempDir.path}/edited_$timestamp.$ext');
+    await tempFile.writeAsBytes(encoded);
     return tempFile;
   }
 
-  /// Process from raw bytes and return PNG bytes.
+  /// Process from raw bytes and return encoded bytes.
   ///
   /// Used on web where [dart:io] filesystem access is unavailable.
   /// Follows the same WYSIWYG render pipeline as [processImage] /
   /// [processImageFromBytes] — the output is pixel-identical.
+  ///
+  /// [outputFormat] controls the encoding of the output. Defaults to
+  /// [ImageOutputFormat.png]. When [ImageOutputFormat.original] is passed the
+  /// format is detected from the input bytes' magic bytes.
   static Future<Uint8List> processImageToBytes({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
+    final effectiveFormat = _resolveEffectiveFormat(outputFormat, bytes);
     if (state.displaySize != null) {
-      return _renderWysiwygToBytes(bytes: bytes, state: state);
+      return _renderWysiwygToBytes(
+        bytes: bytes,
+        state: state,
+        outputFormat: effectiveFormat,
+      );
     }
-    return _processImageFallbackToBytes(bytes: bytes, state: state);
+    return _processImageFallbackToBytes(
+      bytes: bytes,
+      state: state,
+      outputFormat: effectiveFormat,
+    );
   }
 
   /// Pixel-based fallback for [processImageToBytes] (no displaySize).
   static Future<Uint8List> _processImageFallbackToBytes({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
     img.Image? image = img.decodeImage(bytes);
     if (image == null) throw Exception('Failed to decode image');
@@ -262,6 +333,9 @@ class ImageProcessing {
       saturation: state.saturation,
     );
 
+    if (outputFormat == ImageOutputFormat.jpeg) {
+      return Uint8List.fromList(img.encodeJpg(image, quality: 95));
+    }
     return Uint8List.fromList(img.encodePng(image));
   }
 
@@ -269,19 +343,10 @@ class ImageProcessing {
   // Fallback: pixel-based processing (used only when displaySize is unavailable)
   // NOTE: This path is intentionally simple and does NOT account for zoom/pan.
   // ---------------------------------------------------------------------------
-  static Future<File> _processImageFallback({
-    required File originalFile,
-    required ImageEditorState state,
-  }) async {
-    return _processImageFallbackFromBytes(
-      bytes: await originalFile.readAsBytes(),
-      state: state,
-    );
-  }
-
   static Future<File> _processImageFallbackFromBytes({
     required Uint8List bytes,
     required ImageEditorState state,
+    ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
     img.Image? image = img.decodeImage(bytes);
     if (image == null) throw Exception('Failed to decode image');
@@ -311,8 +376,13 @@ class ImageProcessing {
 
     final tempDir = Directory.systemTemp;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final tempFile = File('${tempDir.path}/edited_$timestamp.jpg');
-    await tempFile.writeAsBytes(img.encodeJpg(image, quality: 95));
+    if (outputFormat == ImageOutputFormat.jpeg) {
+      final tempFile = File('${tempDir.path}/edited_$timestamp.jpg');
+      await tempFile.writeAsBytes(img.encodeJpg(image, quality: 95));
+      return tempFile;
+    }
+    final tempFile = File('${tempDir.path}/edited_$timestamp.png');
+    await tempFile.writeAsBytes(img.encodePng(image));
     return tempFile;
   }
 
@@ -340,6 +410,44 @@ class ImageProcessing {
       return image;
     }
     return img.copyRotate(image, angle: degrees);
+  }
+
+  /// Detects the format of [bytes] from its magic-byte signature.
+  ///
+  /// To support additional formats in the future, add a new [_InputFormat]
+  /// value and a corresponding magic-byte check here.
+  static _InputFormat _detectInputFormat(Uint8List bytes) {
+    if (bytes.length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8) {
+      return _InputFormat.jpeg;
+    }
+    // WebP: "RIFF????WEBP" — bytes[0..3] == 52 49 46 46, bytes[8..11] == 57 45 42 50
+    // HEIC/HEIF: ftyp box at offset 4 — not checked here; falls through to PNG default.
+    return _InputFormat.png;
+  }
+
+  /// Resolves [requestedFormat] to either [ImageOutputFormat.png] or
+  /// [ImageOutputFormat.jpeg] by examining [bytes] when needed.
+  ///
+  /// - [auto] → [png] (callers that skip processing for no-change images
+  ///   handle [auto] before reaching this method; when processing does run,
+  ///   PNG is the safe default)
+  /// - [original] → detect from [bytes] magic bytes
+  /// - [png] / [jpeg] → returned unchanged
+  static ImageOutputFormat _resolveEffectiveFormat(
+    ImageOutputFormat requestedFormat,
+    Uint8List bytes,
+  ) {
+    switch (requestedFormat) {
+      case ImageOutputFormat.original:
+        return _detectInputFormat(bytes) == _InputFormat.jpeg
+            ? ImageOutputFormat.jpeg
+            : ImageOutputFormat.png;
+      case ImageOutputFormat.auto:
+        return ImageOutputFormat.png;
+      case ImageOutputFormat.png:
+      case ImageOutputFormat.jpeg:
+        return requestedFormat;
+    }
   }
 
   static img.Image _applyColorAdjustments(

--- a/lib/src/utils/image_processing.dart
+++ b/lib/src/utils/image_processing.dart
@@ -266,8 +266,8 @@ class ImageProcessing {
     required ImageEditorState state,
     ImageOutputFormat outputFormat = ImageOutputFormat.png,
   }) async {
-    final encoded =
-        await _renderWysiwygToBytes(bytes: bytes, state: state, outputFormat: outputFormat);
+    final encoded = await _renderWysiwygToBytes(
+        bytes: bytes, state: state, outputFormat: outputFormat);
     final tempDir = Directory.systemTemp;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
     final ext = outputFormat == ImageOutputFormat.jpeg ? 'jpg' : 'png';

--- a/lib/src/z_image_editor_widget.dart
+++ b/lib/src/z_image_editor_widget.dart
@@ -9,6 +9,7 @@ import 'package:z_image_editor/src/models/adjust_tab_settings.dart';
 import 'package:z_image_editor/src/models/crop_tab_settings.dart';
 import 'package:z_image_editor/src/models/crop_toolbar_settings.dart';
 import 'package:z_image_editor/src/models/image_editor_state.dart';
+import 'package:z_image_editor/src/models/image_output_format.dart';
 import 'package:z_image_editor/src/utils/image_processing.dart';
 import 'package:z_image_editor/src/widgets/adjustment_controls.dart';
 import 'package:z_image_editor/src/widgets/crop_controls.dart';
@@ -77,6 +78,18 @@ class ZImageEditor extends StatefulWidget {
   /// Only relevant when [showAdjustTab] is `true`.
   final AdjustTabSettings adjustTabSettings;
 
+  /// Controls how the output image is encoded when the user presses Done.
+  ///
+  /// - [ImageOutputFormat.auto] *(default)*: skip re-encoding entirely when no
+  ///   edits have been applied (fastest for unmodified images). Re-encodes as
+  ///   PNG when edits are present.
+  /// - [ImageOutputFormat.png]: always re-encode as PNG.
+  /// - [ImageOutputFormat.jpeg]: always re-encode as JPEG.
+  /// - [ImageOutputFormat.original]: preserve the original format. Skips
+  ///   re-encoding when no edits have been applied; otherwise detects the
+  ///   input format from magic bytes and re-encodes to match.
+  final ImageOutputFormat outputFormat;
+
   const ZImageEditor({
     super.key,
     this.imageFiles,
@@ -95,6 +108,7 @@ class ZImageEditor extends StatefulWidget {
     this.cropTabSettings = const CropTabSettings(),
     this.showAdjustTab = true,
     this.adjustTabSettings = const AdjustTabSettings(),
+    this.outputFormat = ImageOutputFormat.auto,
   })  : assert(
           imageFiles != null || imageBytesList != null,
           'Provide imageFiles or imageBytesList.',
@@ -248,20 +262,36 @@ class _ZImageEditorState extends State<ZImageEditor> {
     final state = _controller.state;
     final currentFile = _currentImageFile;
     final currentBytes = _currentImageBytes;
+    final outputFormat = widget.outputFormat;
 
     File processedFile;
 
-    if (!state.hasChanges && currentFile != null) {
+    // For auto/original formats, skip re-encoding entirely when the image
+    // has not been modified — return the original source directly.
+    final skipConversion = !state.hasChanges &&
+        (outputFormat == ImageOutputFormat.auto ||
+            outputFormat == ImageOutputFormat.original);
+
+    if (skipConversion && currentFile != null) {
       processedFile = currentFile;
+    } else if (skipConversion && currentBytes != null) {
+      // Write the original bytes to a temp file without re-encoding.
+      final tempDir = Directory.systemTemp;
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final tempFile = File('${tempDir.path}/edited_$timestamp.tmp');
+      await tempFile.writeAsBytes(currentBytes);
+      processedFile = tempFile;
     } else if (currentFile != null) {
       processedFile = await ImageProcessing.processImage(
         originalFile: currentFile,
         state: state,
+        outputFormat: outputFormat,
       );
     } else if (currentBytes != null) {
       processedFile = await ImageProcessing.processImageFromBytes(
         bytes: currentBytes,
         state: state,
+        outputFormat: outputFormat,
       );
     } else {
       return;
@@ -279,17 +309,31 @@ class _ZImageEditorState extends State<ZImageEditor> {
     final state = _controller.state;
     final currentBytes = _currentImageBytes;
     if (currentBytes == null) return;
+    final outputFormat = widget.outputFormat;
 
-    final pngBytes = await ImageProcessing.processImageToBytes(
-      bytes: currentBytes,
-      state: state,
-    );
+    final Uint8List outputBytes;
+
+    // For auto/original formats, skip re-encoding entirely when the image
+    // has not been modified — return the original bytes directly.
+    final skipConversion = !state.hasChanges &&
+        (outputFormat == ImageOutputFormat.auto ||
+            outputFormat == ImageOutputFormat.original);
+
+    if (skipConversion) {
+      outputBytes = currentBytes;
+    } else {
+      outputBytes = await ImageProcessing.processImageToBytes(
+        bytes: currentBytes,
+        state: state,
+        outputFormat: outputFormat,
+      );
+    }
 
     if (_isLastImage) {
-      _processedImageBytes.add(pngBytes);
+      _processedImageBytes.add(outputBytes);
       widget.onSaveAllBytes!(_processedImageBytes);
     } else {
-      _processedImageBytes.add(pngBytes);
+      _processedImageBytes.add(outputBytes);
       setState(() {
         _currentIndex++;
         _isCropPortrait = false;

--- a/lib/z_image_editor.dart
+++ b/lib/z_image_editor.dart
@@ -5,3 +5,4 @@ export 'src/z_image_editor_widget.dart' show ZImageEditor;
 
 // Models (for advanced usage)
 export 'src/models/image_editor_state.dart';
+export 'src/models/image_output_format.dart';


### PR DESCRIPTION
## Summary

- Eliminates the slow PNG conversion when pressing Done on an unmodified image (the core perf issue from #111)
- Adds `ImageOutputFormat` enum so callers can control the output encoding

## New API

```dart
ZImageEditor(
  outputFormat: ImageOutputFormat.auto, // default — skip conversion if no edits
  // outputFormat: ImageOutputFormat.png     — always PNG
  // outputFormat: ImageOutputFormat.jpeg    — always JPEG
  // outputFormat: ImageOutputFormat.original — match input format; skip if unchanged
  ...
)
```

## Format behaviour

| Format | No edits applied | Edits applied |
|--------|-----------------|---------------|
| `auto` (default) | Return original unchanged | Re-encode as PNG |
| `png` | Re-encode as PNG | Re-encode as PNG |
| `jpeg` | Re-encode as JPEG | Re-encode as JPEG |
| `original` | Return original unchanged | Re-encode to detected input format (JPEG->JPEG, others->PNG) |

**Note:** WebP/HEIC inputs that have been edited fall back to PNG since the `image` package does not support encoding those formats. Unedited WebP/HEIC are always returned unchanged.

## Changes

- `lib/src/models/image_output_format.dart` — new `ImageOutputFormat` enum with extension docs
- `lib/src/utils/image_processing.dart` — `outputFormat` param on all processing methods; JPEG encode path; `_detectInputFormat` + `_resolveEffectiveFormat` helpers
- `lib/src/z_image_editor_widget.dart` — `outputFormat` widget param; `_handleSaveWeb` now skips re-encoding for unchanged images; `_handleSaveMobile` bytes-path also skips re-encoding when unchanged
- `lib/z_image_editor.dart` + `lib/image_editor.dart` — export `ImageOutputFormat`

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
